### PR TITLE
feat: extend validation ruleset and add configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # CommitIt - Conventional Commits Library
 
-Lightweight (Conventional) Commits library, allowing you to retrieve (Conventional) Commits and verify them against the [Conventional Commits specification]
+Lightweight (Conventional) Commits library, allowing you to retrieve (Conventional) Commits and verify them against the [(Extended) Conventional Commits specification]
 
 <img src="./docs/images/example.svg" width="100%">
 
@@ -14,7 +14,7 @@ Lightweight (Conventional) Commits library, allowing you to retrieve (Convention
 
 * Simple to use
 * Retrieving commit messages from your git objects or provided string
-* Validate the commit message against the [Conventional Commits specification]
+* Validate the commit message against the [(Extended) Conventional Commits specification]
 
 ## Basic Usage
 
@@ -24,7 +24,16 @@ import { getCommit, getConventionalCommit } from '@dev-build-deploy/commit-it';
 
 // Retrieve commit from your git objects database
 const gitCommit = getCommit({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
-const conventionalCommit = getConventionalCommit(gitCommit);
+
+// OPTIONAL; Conventional Commits options
+const conventionalOptions = {
+  // EC-01: A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
+  scopes: [ "core", "cli", "action" ],
+
+  // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
+  types: [ "build", "ci", "docs", "perf", "refactor", "style", "test" ],
+}
+const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
 
 // NOTE: See "Non-compliant Conventional Commits message" for details on how to capture failures.
 
@@ -95,4 +104,4 @@ For more, check out the [Contributing Guide](CONTRIBUTING.md).
 - [GPL-3.0-or-later AND CC0-1.0](LICENSE) © 2023 Kevin de Jong \<monkaii@hotmail.com\>
 - [CC-BY-3.0](LICENSE) © 2023 Free Software Foundation Europe e.V.
 
-[Conventional Commits specification]: https://www.conventionalcommits.org/en/v1.0.0/
+[(Extended) Conventional Commits specification]: ./docs/rules.md

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,43 @@
+<!-- 
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: CC-BY-3.0
+-->
+
+# Validation Rules
+
+CommitIt validates against the following sets of specifications:
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- (OPTIONAL) [Extended Conventional Commits specification](#extended-conventional-commits-specification)
+
+## Conventional Commits
+
+| Identifier | Description |
+| --- | --- |
+| `CC-01` | Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space. | 
+| `CC-04` | A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):` |
+| `CC-05` | A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string._ |
+
+> **NOTE**: Above _3_ requirements are covered by _12_ distinct validation rules
+
+## Extended Conventional Commits specification
+
+| Identifier | Description |
+| --- | --- |
+| `EC-01` | A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis |
+| `EC-02` | Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...) |
+
+You can provide the mentioned configuration options as follows:
+
+```ts
+const conventionalOptions = {
+  // EC-01: A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
+  scopes: [ "core", "cli", "action" ],
+
+  // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (...)
+  types: [ "build", "ci", "docs", "perf", "refactor", "style", "test" ],
+}
+
+const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-build-deploy/commit-it",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "(Conventional) Commits library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -89,7 +89,7 @@ function parseCommitFooter(footer: string): Record<string, string> | undefined {
     let value = line.substring(match[1].length).trim();
     if (match[1].endsWith(" #")) {
       key = match[1].substring(0, match[1].length - 2);
-      value = `#${value}`
+      value = `#${value}`;
     }
 
     // Check if the value continues on the next line

--- a/src/conventional_commit.ts
+++ b/src/conventional_commit.ts
@@ -10,6 +10,17 @@ import { ICommit } from "./commit";
 import { ExpressiveMessage } from "@dev-build-deploy/diagnose-it";
 
 /**
+ * Conventional Commit options
+ * @interface IConventionalCommitOptions
+ * @member scopes List of scopes to use when validating the commit message
+ * @member types List of types to use when validating the commit message (NOTE: always includes "feat" and "fix")
+ */
+export interface IConventionalCommitOptions {
+  scopes?: string[];
+  types?: string[];
+}
+
+/**
  * Conventional Commit element
  * @interface IConventionalCommitElement
  * @member index Index of the element in the commit message
@@ -94,10 +105,10 @@ function hasBreakingChange(commit: IRawConventionalCommit): boolean {
  * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
-function validate(commit: IRawConventionalCommit): IConventionalCommit {
+function validate(commit: IRawConventionalCommit, options?: IConventionalCommitOptions): IConventionalCommit {
   let errors: ExpressiveMessage[] = [];
 
-  requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit)]));
+  requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
   if (errors.length > 0) throw new ConventionalCommitError(errors);
 
   // Assume that we have a valid Conventional Commit message
@@ -119,23 +130,17 @@ function validate(commit: IRawConventionalCommit): IConventionalCommit {
  * @returns Whether the provided commit is a Conventional Commit
  */
 export function isConventionalCommit(commit: ICommit | IConventionalCommit): boolean {
-  if ("type" in commit) return true;
-
-  try {
-    getConventionalCommit(commit);
-    return true;
-  } catch (error) {
-    return false;
-  }
+  return "type" in commit;
 }
 
 /**
  * Parses a Commit message into a Conventional Commit.
  * @param commit Commit message to parse
+ * @param options Options to use when parsing the commit message
  * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
  * @returns Conventional Commit
  */
-export function getConventionalCommit(commit: ICommit): IConventionalCommit {
+export function getConventionalCommit(commit: ICommit, options?: IConventionalCommitOptions): IConventionalCommit {
   const ConventionalCommitRegex = new RegExp(
     /^(?<type>[^(!:]*)(?<scope>\(.*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/
   );
@@ -163,5 +168,5 @@ export function getConventionalCommit(commit: ICommit): IConventionalCommit {
 
   conventionalCommit = intializeIndices(conventionalCommit);
 
-  return validate(conventionalCommit);
+  return validate(conventionalCommit, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@ export {
   isConventionalCommit,
   ConventionalCommitError,
   IConventionalCommit,
+  IConventionalCommitOptions,
 } from "./conventional_commit";

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -213,4 +213,5 @@ class EC02 implements ICommitRequirement {
   }
 }
 
+/** @internal */
 export const commitRules: ICommitRequirement[] = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];

--- a/test/example.test.ts
+++ b/test/example.test.ts
@@ -15,11 +15,20 @@ describe("Validate example code in README.md", () => {
   test("Git Source", () => {
     // Retrieve commit from your git objects database
     const gitCommit = getCommit({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
-    const conventionalCommit = getConventionalCommit(gitCommit);
+
+    // OPTIONAL; Conventional Commits options
+    const conventionalOptions = {
+      // EC-01: A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
+      scopes: [ "core", "cli", "action" ],
+      
+      // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (...)
+      types: [ "build", "ci", "docs", "perf", "refactor", "style", "test" ],
+    }
+    const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
 
     // NOTE: See "Non-compliant Conventional Commits message" for details on how to capture failures.
 
-    console.log(JSON.stringify(conventionalCommit, null, 2));
+    console.log(JSON.stringify(conventionalCommit, null, 2))
   });
 
   test("String Source", () => {

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -137,7 +137,7 @@ BREAKING-CHANGE: This is a breaking change
       body: undefined,
       footer: {
         "Acknowledged-by": "Jane Doe",
-      }
+      },
     });
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: multiFooter })).toStrictEqual({
@@ -149,7 +149,7 @@ BREAKING-CHANGE: This is a breaking change
       footer: {
         "Acknowledged-by": "Jane Doe",
         "Signed-off-by": "John Doe",
-      }
+      },
     });
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: paragraphFooter })).toStrictEqual({
@@ -162,7 +162,7 @@ BREAKING-CHANGE: This is a breaking change
         "Acknowledged-by": "Jane Doe",
         "Signed-off-by": "John Doe",
         "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
-      }
+      },
     });
   });
 
@@ -190,8 +190,8 @@ Implements #1234`;
         "Acknowledged-by": "Jane Doe",
         "Signed-off-by": "John Doe",
         "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
-        "Implements": "#1234",
-      }
+        Implements: "#1234",
+      },
     });
   });
 });


### PR DESCRIPTION
Introduces two additional rules:
- A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
- Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)

You can provide the mentioned configuration options as follows:

```ts
const conventionalOptions = {
  // EC-01: A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  scopes: [ "core", "cli", "action" ],

  // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (...)
  types: [ "build", "ci", "docs", "perf", "refactor", "style", "test" ],
}

const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
```