### PR TITLE
feat!: upgrade diagnose-it to provide better error message output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dev-build-deploy/diagnose-it": "<1.0.0"
+        "@dev-build-deploy/diagnose-it": "^1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -698,11 +698,13 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/diagnose-it": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/diagnose-it/-/diagnose-it-0.4.2.tgz",
-      "integrity": "sha512-yhEWjsNMdbEsrIc8yp6ahZLGRfIlGRUe3odImgwMfgyHFNwWKKL8ivMQEZuqJ9Rs8QvN5uBaJ/bDISvkAfEdhw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/diagnose-it/-/diagnose-it-1.4.1.tgz",
+      "integrity": "sha512-XXS4zxxOMv6Ybx9l+IxvrURFXXqxJheSrdi3LnFE2oUrVsjmKFlRYtspSFqQGkM/MCIfsNZxplhON2BmKLCJ8g==",
       "dependencies": {
-        "@dev-build-deploy/sarif-it": "<1"
+        "@dev-build-deploy/sarif-it": "<1",
+        "chalk": "<5",
+        "diff": "^5.1.0"
       }
     },
     "node_modules/@dev-build-deploy/sarif-it": {
@@ -1709,7 +1711,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2127,7 +2128,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2203,7 +2203,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2214,8 +2213,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2348,6 +2346,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -3333,7 +3339,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5615,7 +5620,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "lib/*"
   ],
   "dependencies": {
-    "@dev-build-deploy/diagnose-it": "<1.0.0"
+    "@dev-build-deploy/diagnose-it": "^1"
   }
 }

--- a/src/conventional_commit.ts
+++ b/src/conventional_commit.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 import assert from "assert";
 
-import { ExpressiveMessage } from "@dev-build-deploy/diagnose-it";
+import { DiagnosticsMessage } from "@dev-build-deploy/diagnose-it";
 
 import { ICommit } from "./commit";
 import * as requirements from "./requirements";
@@ -78,8 +78,8 @@ export interface IConventionalCommit extends ICommit {
  * @member errors List of error messages
  */
 export class ConventionalCommitError extends Error {
-  errors: ExpressiveMessage[];
-  constructor(errors: ExpressiveMessage[]) {
+  errors: DiagnosticsMessage[];
+  constructor(errors: DiagnosticsMessage[]) {
     super("Commit is not compliant with the Conventional Commits specification.");
     this.name = "ConventionalCommitError";
     this.errors = errors;
@@ -107,7 +107,7 @@ function hasBreakingChange(commit: IRawConventionalCommit): boolean {
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
 function validate(commit: IRawConventionalCommit, options?: IConventionalCommitOptions): IConventionalCommit {
-  let errors: ExpressiveMessage[] = [];
+  let errors: DiagnosticsMessage[] = [];
 
   requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
   if (errors.length > 0) throw new ConventionalCommitError(errors);

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -36,6 +36,8 @@ const validateRequirement = (message: string, expected: string, options?: IConve
           error.errors.map(e => e.message).join("\n")
         )}`
       );
+    } else {
+      error.errors.forEach(e => console.log(e.toString()));
     }
   }
 };

--- a/test/example.test.ts
+++ b/test/example.test.ts
@@ -42,7 +42,7 @@ describe("Validate example code in README.md", () => {
     } catch (error: unknown) {
       if (!(error instanceof ConventionalCommitError)) throw error;
 
-      error.errors.forEach(e => console.log(e.message));
+      error.errors.forEach(e => console.log(e.toString()));
     }
   });
 });


### PR DESCRIPTION
This commit upgrades `diagnose-it` to `@v1` as this provides support for FixIt Hints, providing output more consistent with the LLVM specification.

This is a BREAKING CHANGE as we now throw validation errors incl. the type `DiagnosticsMessage` instead of `ExpressiveMessage`