### PR TITLE
feat!: add several new rules (errors and warnings)

### DIFF
--- a/.github/.commit-me.json
+++ b/.github/.commit-me.json
@@ -1,0 +1,3 @@
+{
+  "types": [ "build", "chore", "ci", "docs", "style", "refactor", "perf", "test" ]
+}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run CommitMe
-        uses: dev-build-deploy/commit-me@v0
+        uses: dev-build-deploy/commit-me@v1
         with:
           token: ${{ github.token }}
           include-commits: true
+          config: .github/.commit-me.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,12 @@
 
 repos:
 - repo: https://github.com/dev-build-deploy/commit-me
-  rev: v0.13.0
+  rev: v1.1.0
   hooks:
   - id: commit-me
+    args: ['--config', '.github/.commit-me.json']
+
 - repo: https://github.com/dev-build-deploy/reuse-me
-  rev: v0.10.0
+  rev: v1.0.0
   hooks:
   - id: reuse-me

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -22,3 +22,7 @@ License: CC0-1.0
 Files: package*.json
 Copyright: 2023 Kevin de Jong <monkaii@hotmail.com>
 License: CC0-1.0
+
+Files: .github/.commit-me.json
+Copyright: 2023 Kevin de Jong <monkaii@hotmail.com>
+License: CC0-1.0

--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ Lightweight (Conventional) Commits library, allowing you to retrieve (Convention
 
 ## Basic Usage
 
-### Compliant Conventional Commits message
+### Commit Message
 ```ts
-import { getCommit, getConventionalCommit } from '@dev-build-deploy/commit-it';
+import { Commit } from "@dev-build-deploy/commit-it";
 
-// Retrieve commit from your git objects database
-const gitCommit = getCommit({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
+const gitCommit = Commit.fromHash({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
+console.log(JSON.stringify(gitCommit, null, 2))
+```
+
+### Conventional Commit message (compliant)
+```ts
+import { ConventionalCommit } from '@dev-build-deploy/commit-it';
 
 // OPTIONAL; Conventional Commits options
 const conventionalOptions = {
@@ -31,12 +36,15 @@ const conventionalOptions = {
 
   // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
   types: [ "build", "ci", "docs", "perf", "refactor", "style", "test" ],
-}
-const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
+};
+
+const conventionalCommit = ConventionalCommit.fromHash(
+  { hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" },
+  conventionalOptions
+);
 
 // NOTE: See "Non-compliant Conventional Commits message" for details on how to capture failures.
-
-console.log(JSON.stringify(conventionalCommit, null, 2))
+console.log(JSON.stringify(conventionalCommit, null, 2));
 ```
 <details>
   <summary>Output...</summary>
@@ -59,30 +67,31 @@ console.log(JSON.stringify(conventionalCommit, null, 2))
   },
   "type": "feat",
   "breaking": false,
-  "description": "mark Conventional Commit as 'breaking' in case specified in the footer"
+  "description": "mark Conventional Commit as 'breaking' in case specified in the footer",
+  "validation": {
+    "isValid": true,
+    "errors": [],
+    "warnings": []
+  }
 }
 ```
 
 </details>
 <br>
 
-### Non-compliant Conventional Commits message
+### Conventional Commit message (non-compliant)
 
 ```ts
-import { getCommit, getConventionalCommit, ConventionalCommitError } from '@dev-build-deploy/commit-it';
+import { ConventionalCommit } from '@dev-build-deploy/commit-it';
 
 // Provide a commit message as a string
-const gitCommit = getCommit({
+const conventionalCommit = ConventionalCommit.fromString({
   hash: "0ab1cd2ef",
   message: "feat (no noun): non-compliant conventional commits message",
 });
 
-try {
-  getConventionalCommit(gitCommit); // NOTE: this is an explicit failure
-} catch (error: unknown) {
-  if (!(error instanceof ConventionalCommitError)) throw error;
-
-  error.errors.forEach(e => console.log(e.message));
+if (!conventionalCommit.isValid) {
+  conventionalCommit.errors.forEach(e => console.log(e.toString()));
 }
 ```
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -19,6 +19,7 @@ CommitIt validates against the following sets of specifications:
 | `CC-04` | A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):` |
 | `CC-05` | A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string._ |
 | `CC-06` | A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description. |
+| `CC-15` | The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase. |
 
 > **NOTE**: Above _3_ requirements are covered by _12_ distinct validation rules
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -42,3 +42,11 @@ const conventionalOptions = {
 
 const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
 ```
+
+## Additional warnings
+
+In order to warn users about edge cases, several warning messages have been introduced to prevent unwanted behavior:
+
+| Identifier | Description |
+| --- | --- |
+| `WA-01` | A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer. |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@ CommitIt validates against the following sets of specifications:
 | `CC-01` | Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space. | 
 | `CC-04` | A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):` |
 | `CC-05` | A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string._ |
+| `CC-06` | A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description. |
 
 > **NOTE**: Above _3_ requirements are covered by _12_ distinct validation rules
 

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -60,12 +60,13 @@ export interface ICommit {
   author?: { name: string; date: Date };
   committer?: { name: string; date: Date };
   hash: string;
+  raw: string;
   subject: string;
   body?: string;
   footer?: Record<string, string>;
 }
 
-const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/;
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
 
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
@@ -189,6 +190,7 @@ export function getCommit(
       ...parseCommitMessage(stringOptions.message),
       author: stringOptions.author,
       committer: stringOptions.committer,
+      raw: stringOptions.message,
     };
     // GitHub data source
   } else if ("owner" in options) {
@@ -198,6 +200,7 @@ export function getCommit(
     commit = {
       hash: githubOptions.hash,
       subject: "",
+      raw: "",
     };
     // Git data source
   } else {

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -65,6 +65,8 @@ export interface ICommit {
   footer?: Record<string, string>;
 }
 
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/;
+
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -81,7 +83,7 @@ function parseCommitFooter(footer: string): Record<string, string> | undefined {
 
   for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
     const line = footerLines[lineNr];
-    const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const match = TRAILER_REGEX.exec(line);
     if (match === null) continue;
 
     let key = match[1].replace(/:$/, "");
@@ -92,7 +94,10 @@ function parseCommitFooter(footer: string): Record<string, string> | undefined {
     }
 
     // Check if the value continues on the next line
-    while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+    while (
+      lineNr + 1 < footerLines.length &&
+      (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)
+    ) {
       lineNr++;
       value += "\n" + footerLines[lineNr].trim();
     }
@@ -117,7 +122,7 @@ export function parseCommitMessage(message: string): {
 } {
   const isTrailerOnly = (message: string): boolean =>
     message.split(/[\r\n]+/).every(line => {
-      const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+      const match = TRAILER_REGEX.exec(line);
       return match !== null;
     });
 

--- a/src/conventional_commit.ts
+++ b/src/conventional_commit.ts
@@ -145,7 +145,7 @@ export function getConventionalCommit(commit: ICommit, options?: IConventionalCo
     /^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/
   );
 
-  const match = ConventionalCommitRegex.exec(commit.subject);
+  const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
   let conventionalCommit: IRawConventionalCommit = {
     commit: commit,
     type: { index: 1, value: match?.groups?.type },

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,7 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import assert from "assert";
 import * as fs from "fs";

--- a/src/git.ts
+++ b/src/git.ts
@@ -16,6 +16,7 @@ type NameAndDateType = { name: string; date: Date };
 /** @internal */
 type GitCommitType = {
   hash: string;
+  raw: string;
   author?: NameAndDateType;
   committer?: NameAndDateType;
   subject: string;
@@ -73,18 +74,18 @@ function getValueFromKey(commit: string, key: string): string | undefined {
 function parseCommitMessage(commit: string, hash: string): GitCommitType {
   const author = extractNameAndDate(getValueFromKey(commit, "author"));
   const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+  const raw = commit
+    .split(/^[\r\n]+/m)
+    .splice(1)
+    .join("\n")
+    .trim();
 
   return {
+    raw,
     hash: hash,
     author: author,
     committer: committer,
-    ...ccommit.parseCommitMessage(
-      commit
-        .split(/^[\r\n]+/m)
-        .splice(1)
-        .join("\n")
-        .trim()
-    ),
+    ...ccommit.parseCommitMessage(raw),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,8 @@
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
-export {
-  getCommit,
-  ICommit,
-  IGitDataSourceOptions,
-  IStringDataSourceOptions,
-  IGitHubDataSourceOptions,
-} from "./commit";
-export {
-  getConventionalCommit,
-  isConventionalCommit,
-  ConventionalCommitError,
-  IConventionalCommit,
-  IConventionalCommitOptions,
-} from "./conventional_commit";
+export { Commit } from "./commit";
+export { ConventionalCommit } from "./conventional_commit";
+export type { IConventionalCommitOptions } from "./conventional_commit";

--- a/test/commit.test.ts
+++ b/test/commit.test.ts
@@ -1,0 +1,96 @@
+/* 
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+
+import * as commit from "../src/commit";
+
+describe("Valid singleline footer elements", () => {
+  const tests = [
+    { footers: undefined },
+    { footers: { "co-authored-by": "Kevin de Jong" } },
+    {
+      footers: {
+        "co-authored-by": "Kevin de Jong",
+        "acknowledged-by": "Jane Doe",
+      },
+    },
+    { footers: { "BREAKING CHANGE": "This is a breaking change" } },
+    { footers: { "BREAKING-CHANGE": "This is a breaking change" } },
+  ];
+
+  it.each(tests)("$footers", test => {
+    const commitMessage = commit.parseCommitMessage(`feat: example commit
+
+${Object.entries(test.footers ?? {})
+  .map(([key, value]) => `${key}: ${value}`)
+  .join("\n")}`);
+    expect(commitMessage.footer).toStrictEqual(test.footers);
+  });
+});
+
+describe("Valid multiline footer elements", () => {
+  const tests = [
+    {
+      input: { "BREAKING CHANGE": "This is a breaking change\n covering multiple lines\n and not one, but two" },
+      expectations: { "BREAKING CHANGE": "This is a breaking change\ncovering multiple lines\nand not one, but two" },
+    },
+    {
+      input: { "BREAKING CHANGE": "This is a breaking change\n covering multiple lines\n \n including an empty line" },
+      expectations: {
+        "BREAKING CHANGE": "This is a breaking change\ncovering multiple lines\n\nincluding an empty line",
+      },
+    },
+  ];
+
+  it.each(tests)("$input", test => {
+    const commitMessage = commit.parseCommitMessage(`feat: example commit
+
+${Object.entries(test.input ?? {})
+  .map(([key, value]) => `${key}: ${value}`)
+  .join("\n")}`);
+    console.log(commitMessage);
+    expect(commitMessage.footer).toStrictEqual(test.expectations);
+  });
+});
+
+describe("Invalid Footer Elements", () => {
+  const tests = [
+    {
+      message: `feat: invalid footer element
+
+co authored by: Kevin de Jong`,
+      footers: undefined,
+    },
+    {
+      message: `feat: ignore footer element
+
+acknowledged by: Jane Doe
+
+This commit has been acknowledged, but a paragraph preceeds the footer`,
+      footers: undefined,
+    },
+    {
+      message: `feat: ignore footer element
+
+BREAKING CHANGE: This is a multiline breaking change
+in which we do not manage multiline correctly`,
+      footers: undefined,
+    },
+    {
+      message: `feat: Ignore initial footer element, but not the second
+
+acknowledged by: Jane Doe
+
+This commit has been acknowledged, but a paragraph preceeds the footer
+
+BREAKING CHANGE: This is a breaking change`,
+      footers: { "BREAKING CHANGE": "This is a breaking change" },
+    },
+  ];
+
+  it.each(tests)("$footers", test => {
+    const commitMessage = commit.parseCommitMessage(test.message);
+    expect(commitMessage.footer).toStrictEqual(test.footers);
+  });
+});

--- a/test/commit.test.ts
+++ b/test/commit.test.ts
@@ -1,7 +1,7 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import * as commit from "../src/commit";
 

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -123,6 +123,18 @@ describe("CC-05", () => {
   });
 });
 
+describe("CC-06", () => {
+  const tests = [
+    { message: "feat: add new feature\nLine 1" },
+    { message: "feat: add new feature\nLine 1\nLine 2" },
+    { message: "feat: add new feature\nLine 1\n\nBody" },
+  ];
+
+  it.each(tests)("$message", test => {
+    validateRequirement(test.message, "The body MUST begin one blank line after the description");
+  });
+});
+
 describe("EC-01", () => {
   const tests = [
     { message: "feat(wrong): unknown scope" },

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -54,7 +54,13 @@ describe("Valid Conventional Commit subjects", () => {
     expect(() => {
       const commit = commitIt.getCommit({ hash: "01ab2cd3", message: test.message });
       expect(commitIt.isConventionalCommit(commit)).toBe(false);
-      expect(commitIt.isConventionalCommit(commitIt.getConventionalCommit(commit))).toBe(true);
+      expect(
+        commitIt.isConventionalCommit(
+          commitIt.getConventionalCommit(commit, {
+            scopes: ["login"],
+          })
+        )
+      ).toBe(true);
     }).not.toThrow();
   });
 });
@@ -118,7 +124,12 @@ describe("CC-05", () => {
 });
 
 describe("EC-01", () => {
-  const tests = [{ message: "feat(wrong): unknown scope" }];
+  const tests = [
+    { message: "feat(wrong): unknown scope" },
+    { message: "feat (wrong): spacing as prefix" },
+    { message: "feat(wrong) : spacing as suffix" },
+    { message: "feat ( wrong ) : spacing everywhere" },
+  ];
 
   it.each(tests)("$message", test => {
     validateRequirement(

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -48,6 +48,7 @@ describe("Valid Conventional Commit subjects", () => {
     { message: "fix: fix bug" },
     { message: "fix!: fix bug with breaking change" },
     { message: "feat(login): add support google oauth (#12)" },
+    { message: "FEAT: capitalized" },
   ];
 
   it.each(tests)("$message", test => {
@@ -135,6 +136,21 @@ describe("CC-06", () => {
   });
 });
 
+describe("CC-15", () => {
+  const tests = [
+    { message: "feat: add new feature\n\nBreAking-ChaNGe: This is incorrectly formatted!" },
+    { message: "feat: add new feature\n\nbreaking change: This is incorrectly formatted!" },
+    { message: "feat: add new feature\n\nbreaking-change: This is incorrectly formatted!" },
+  ];
+
+  it.each(tests)("$message", test => {
+    validateRequirement(
+      test.message,
+      "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase."
+    );
+  });
+});
+
 describe("EC-01", () => {
   const tests = [
     { message: "feat(wrong): unknown scope" },
@@ -203,6 +219,7 @@ describe("Breaking Change", () => {
     expect(
       commitIt.getConventionalCommit({
         hash: "01ab2cd3",
+        raw: "feat: add new feature without breaking change",
         subject: "feat: add new feature without breaking change",
       }).breaking
     ).toBe(false);
@@ -210,6 +227,7 @@ describe("Breaking Change", () => {
     expect(
       commitIt.getConventionalCommit({
         hash: "01ab2cd3",
+        raw: "feat!: add new feature with breaking change",
         subject: "feat!: add new feature with breaking change",
       }).breaking
     ).toBe(true);
@@ -217,6 +235,9 @@ describe("Breaking Change", () => {
     expect(
       commitIt.getConventionalCommit({
         hash: "01ab2cd3",
+        raw: `feat!: add new feature with breaking change in footer
+
+BREAKING CHANGE: this is a breaking change`,
         subject: "feat: add new feature with breaking change in footer",
         footer: {
           "BREAKING CHANGE": "this is a breaking change",
@@ -227,6 +248,9 @@ describe("Breaking Change", () => {
     expect(
       commitIt.getConventionalCommit({
         hash: "01ab2cd3",
+        raw: `feat!: add new feature with breaking change in footer
+
+BREAKING-CHANGE: this is a breaking change`,
         subject: "feat: add new feature with breaking change in footer",
         footer: {
           "BREAKING-CHANGE": "this is a breaking change",

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -176,6 +176,28 @@ describe("EC-02", () => {
   });
 });
 
+describe("WA-01", () => {
+  const tests = [
+    { message: "feat: add a new feature\n\nBREAKING CHANGE: this is a breaking change\n\nImplements #123" },
+    { message: "feat: add a new feature\n\nBREAKING-CHANGE: this is a breaking change\n\nImplements #123" },
+    {
+      message:
+        "feat: add a new feature\nwith a subject spanning multiple lines\n\nBREAKING-CHANGE: this is a breaking change\n\nImplements #123",
+    },
+    {
+      message:
+        "feat: add a new feature\nwith a subject spanning multiple lines\n\nLets add more lines in the body,\njust because we can\n\nco-authored-by: Bob the Builder\nBREAKING-CHANGE: this is a breaking change\n spanning two lines\n\nImplements #123!",
+    },
+  ];
+
+  it.each(tests)("$message", test => {
+    validateRequirement(
+      test.message,
+      "git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer."
+    );
+  });
+});
+
 describe("Breaking Change", () => {
   test("Has breaking change", () => {
     expect(

--- a/test/example.test.ts
+++ b/test/example.test.ts
@@ -1,10 +1,10 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import * as git from "../src/git";
-import { getCommit, getConventionalCommit, ConventionalCommitError } from "../src/index";
+import { Commit, ConventionalCommit } from "../src/index";
 
 describe("Validate example code in README.md", () => {
   beforeAll(() => {
@@ -13,7 +13,7 @@ describe("Validate example code in README.md", () => {
 
   test("Git Source", () => {
     // Retrieve commit from your git objects database
-    const gitCommit = getCommit({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
+    const gitCommit = Commit.fromHash({ hash: "f1aaa6e0b89eb87b591ab623053845b5d5488d9f" });
 
     // OPTIONAL; Conventional Commits options
     const conventionalOptions = {
@@ -23,7 +23,7 @@ describe("Validate example code in README.md", () => {
       // EC-02: Commits MUST be prefixed with a type, which consists of one of the configured values (...)
       types: ["build", "ci", "docs", "perf", "refactor", "style", "test"],
     };
-    const conventionalCommit = getConventionalCommit(gitCommit, conventionalOptions);
+    const conventionalCommit = ConventionalCommit.fromCommit(gitCommit, conventionalOptions);
 
     // NOTE: See "Non-compliant Conventional Commits message" for details on how to capture failures.
 
@@ -32,17 +32,12 @@ describe("Validate example code in README.md", () => {
 
   test("String Source", () => {
     // Provide a commit message as a string
-    const gitCommit = getCommit({
+    const gitCommit = Commit.fromString({
       hash: "0ab1cd2ef",
       message: "feat (no noun): non-compliant conventional commits message",
     });
 
-    try {
-      getConventionalCommit(gitCommit); // NOTE: this is an explicit failure
-    } catch (error: unknown) {
-      if (!(error instanceof ConventionalCommitError)) throw error;
-
-      error.errors.forEach(e => console.log(e.toString()));
-    }
+    const commit = ConventionalCommit.fromCommit(gitCommit); // NOTE: this is an explicit failure
+    commit.errors.forEach(e => console.log(e.toString()));
   });
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -14,6 +14,13 @@ describe("Get Commit Message from git", () => {
   test("Hash from Local Repository", () => {
     const commit = commitIt.getCommit({ hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95" });
     expect(commit).toStrictEqual({
+      raw: `feat: add support to retrieve commits from a git source by SHA
+
+This commit introduces custom parsing of the objects and pack files
+in .git/objects. Rationale: remove any need for external dependencies
+(albeit packages or tools).
+
+Calling \`getCommitMessage(...)\` will return a standard ICommit object`,
       author: {
         name: "Kevin de Jong <monkaii@hotmail.com>",
         date: new Date("2023-06-16T15:01:30.000Z"),
@@ -36,6 +43,7 @@ Calling \`getCommitMessage(...)\` will return a standard ICommit object`,
   test("Hash from Pack file", () => {
     const commit = commitIt.getCommit({ hash: "78e505dc465c3c39a179f6d24970c2f0f0dccad9" });
     expect(commit).toStrictEqual({
+      raw: `Initial commit`,
       author: {
         name: "Kevin de Jong <134343960+Kevin-de-Jong@users.noreply.github.com>",
         date: new Date("2023-06-16T14:28:58.000Z"),

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,10 +1,10 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import * as git from "../src/git";
-import * as commitIt from "../src/index";
+import { Commit } from "../src/index";
 
 describe("Get Commit Message from git", () => {
   beforeAll(() => {
@@ -12,68 +12,72 @@ describe("Get Commit Message from git", () => {
   });
 
   test("Hash from Local Repository", () => {
-    const commit = commitIt.getCommit({ hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95" });
-    expect(commit).toStrictEqual({
-      raw: `feat: add support to retrieve commits from a git source by SHA
+    const commit = Commit.fromHash({ hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95" });
+    expect(commit).toEqual({
+      _commit: {
+        raw: `feat: add support to retrieve commits from a git source by SHA
 
 This commit introduces custom parsing of the objects and pack files
 in .git/objects. Rationale: remove any need for external dependencies
 (albeit packages or tools).
 
 Calling \`getCommitMessage(...)\` will return a standard ICommit object`,
-      author: {
-        name: "Kevin de Jong <monkaii@hotmail.com>",
-        date: new Date("2023-06-16T15:01:30.000Z"),
-      },
-      committer: {
-        name: "Kevin de Jong <monkaii@hotmail.com>",
-        date: new Date("2023-06-18T00:19:43.000Z"),
-      },
-      hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95",
-      subject: "feat: add support to retrieve commits from a git source by SHA",
-      body: `This commit introduces custom parsing of the objects and pack files
+        author: {
+          name: "Kevin de Jong <monkaii@hotmail.com>",
+          date: new Date("2023-06-16T15:01:30.000Z"),
+        },
+        committer: {
+          name: "Kevin de Jong <monkaii@hotmail.com>",
+          date: new Date("2023-06-18T00:19:43.000Z"),
+        },
+        hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95",
+        subject: "feat: add support to retrieve commits from a git source by SHA",
+        body: `This commit introduces custom parsing of the objects and pack files
 in .git/objects. Rationale: remove any need for external dependencies
 (albeit packages or tools).
 
 Calling \`getCommitMessage(...)\` will return a standard ICommit object`,
-      footer: undefined,
+        footer: undefined,
+      } as Commit,
     });
   });
 
   test("Hash from Pack file", () => {
-    const commit = commitIt.getCommit({ hash: "78e505dc465c3c39a179f6d24970c2f0f0dccad9" });
-    expect(commit).toStrictEqual({
-      raw: `Initial commit`,
-      author: {
-        name: "Kevin de Jong <134343960+Kevin-de-Jong@users.noreply.github.com>",
-        date: new Date("2023-06-16T14:28:58.000Z"),
-      },
-      committer: {
-        name: "GitHub <noreply@github.com>",
-        date: new Date("2023-06-16T14:28:58.000Z"),
-      },
-      hash: "78e505dc465c3c39a179f6d24970c2f0f0dccad9",
-      subject: "Initial commit",
-      body: undefined,
-      footer: undefined,
+    const commit = Commit.fromHash({ hash: "78e505dc465c3c39a179f6d24970c2f0f0dccad9" });
+    expect(commit).toEqual({
+      _commit: {
+        raw: `Initial commit`,
+        author: {
+          name: "Kevin de Jong <134343960+Kevin-de-Jong@users.noreply.github.com>",
+          date: new Date("2023-06-16T14:28:58.000Z"),
+        },
+        committer: {
+          name: "GitHub <noreply@github.com>",
+          date: new Date("2023-06-16T14:28:58.000Z"),
+        },
+        hash: "78e505dc465c3c39a179f6d24970c2f0f0dccad9",
+        subject: "Initial commit",
+        body: undefined,
+        footer: undefined,
+      } as Commit,
     });
   });
 
   test("Invalid hash", () => {
-    expect(() => commitIt.getCommit({ hash: "d0dbf83579080ee214b50551a2be587b218e4088" })).toThrow(
+    expect(() => Commit.fromHash({ hash: "d0dbf83579080ee214b50551a2be587b218e4088" })).toThrow(
       "Could not find commit message for hash d0dbf83579080ee214b50551a2be587b218e4088"
     );
   });
 
   test("Invalid git folder", () => {
     expect(() =>
-      commitIt.getCommit({ hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95", rootPath: "does/not/exists" })
+      Commit.fromHash({ hash: "4b1c9f2e8d113892fb7bfc388606c82ce0572b95", rootPath: "does/not/exists" })
     ).toThrow("Invalid git folder specified (does/not/exists/test/environment/objects)");
   });
 
   test("Invalid hash and git folder", () => {
     expect(() =>
-      commitIt.getCommit({ hash: "d0dbf83579080ee214b50551a2be587b218e4088", rootPath: "does/not/exists" })
+      Commit.fromHash({ hash: "d0dbf83579080ee214b50551a2be587b218e4088", rootPath: "does/not/exists" })
     ).toThrow("Invalid git folder specified (does/not/exists/test/environment/objects)");
   });
 });

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -1,91 +1,99 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
-import * as commitIt from "../src/index";
+import { Commit } from "../src/index";
 
 describe("Parse commit messages", () => {
   test("Author", () => {
     expect(
-      commitIt.getCommit({
+      Commit.fromString({
         hash: "0a0b0c0d",
         author: { name: "Jane Doe", date: new Date("2023-06-16T14:28:58.000Z") },
         message: "Example commit message without body or footer",
       })
-    ).toStrictEqual({
-      raw: `Example commit message without body or footer`,
-      hash: "0a0b0c0d",
-      author: {
-        name: "Jane Doe",
-        date: new Date("2023-06-16T14:28:58.000Z"),
+    ).toEqual({
+      _commit: {
+        raw: `Example commit message without body or footer`,
+        hash: "0a0b0c0d",
+        author: {
+          name: "Jane Doe",
+          date: new Date("2023-06-16T14:28:58.000Z"),
+        },
+        committer: undefined,
+        subject: "Example commit message without body or footer",
+        body: undefined,
+        footer: undefined,
       },
-      committer: undefined,
-      subject: "Example commit message without body or footer",
-      body: undefined,
-      footer: undefined,
     });
   });
 
   test("Committer", () => {
     expect(
-      commitIt.getCommit({
+      Commit.fromString({
         hash: "0a0b0c0d",
         committer: { name: "Jane Doe", date: new Date("2023-06-16T14:28:58.000Z") },
         message: "Example commit message without body or footer",
       })
-    ).toStrictEqual({
-      raw: `Example commit message without body or footer`,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: {
-        name: "Jane Doe",
-        date: new Date("2023-06-16T14:28:58.000Z"),
+    ).toEqual({
+      _commit: {
+        raw: `Example commit message without body or footer`,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: {
+          name: "Jane Doe",
+          date: new Date("2023-06-16T14:28:58.000Z"),
+        },
+        subject: "Example commit message without body or footer",
+        body: undefined,
+        footer: undefined,
       },
-      subject: "Example commit message without body or footer",
-      body: undefined,
-      footer: undefined,
     });
   });
 
   test("Subject only", () => {
-    expect(
-      commitIt.getCommit({ hash: "0a0b0c0d", message: "Example commit message without body or footer" })
-    ).toStrictEqual({
-      raw: `Example commit message without body or footer`,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message without body or footer",
-      body: undefined,
-      footer: undefined,
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: "Example commit message without body or footer" })).toEqual({
+      _commit: {
+        raw: `Example commit message without body or footer`,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message without body or footer",
+        body: undefined,
+        footer: undefined,
+      },
     });
 
     expect(
-      commitIt.getCommit({ hash: "0a0b0c0d", message: `Example commit message without body or footer, with newline\n` })
-    ).toStrictEqual({
-      raw: `Example commit message without body or footer, with newline\n`,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message without body or footer, with newline",
-      body: undefined,
-      footer: undefined,
+      Commit.fromString({ hash: "0a0b0c0d", message: `Example commit message without body or footer, with newline\n` })
+    ).toEqual({
+      _commit: {
+        raw: `Example commit message without body or footer, with newline\n`,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message without body or footer, with newline",
+        body: undefined,
+        footer: undefined,
+      },
     });
 
     expect(
-      commitIt.getCommit({
+      Commit.fromString({
         hash: "0a0b0c0d",
         message: `Example commit message without body or footer, with newlines\n\n`,
       })
-    ).toStrictEqual({
-      raw: `Example commit message without body or footer, with newlines\n\n`,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message without body or footer, with newlines",
-      body: undefined,
-      footer: undefined,
+    ).toEqual({
+      _commit: {
+        raw: `Example commit message without body or footer, with newlines\n\n`,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message without body or footer, with newlines",
+        body: undefined,
+        footer: undefined,
+      },
     });
   });
 
@@ -99,24 +107,28 @@ This is the body of the commit message
 with multiple lines
 
 and paragraphs`;
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: singleBody })).toStrictEqual({
-      raw: singleBody,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with body",
-      body: "This is the body of the commit message",
-      footer: undefined,
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: singleBody })).toEqual({
+      _commit: {
+        raw: singleBody,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with body",
+        body: "This is the body of the commit message",
+        footer: undefined,
+      },
     });
 
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: multiBody })).toStrictEqual({
-      raw: multiBody,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with body",
-      body: `This is the body of the commit message\nwith multiple lines\n\nand paragraphs`,
-      footer: undefined,
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: multiBody })).toEqual({
+      _commit: {
+        raw: multiBody,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with body",
+        body: `This is the body of the commit message\nwith multiple lines\n\nand paragraphs`,
+        footer: undefined,
+      },
     });
   });
 
@@ -135,42 +147,48 @@ Signed-off-by: John Doe
 BREAKING-CHANGE: This is a breaking change
  using multiple lines as value`;
 
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: singleFooter })).toStrictEqual({
-      raw: singleFooter,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with footer",
-      body: undefined,
-      footer: {
-        "Acknowledged-by": "Jane Doe",
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: singleFooter })).toEqual({
+      _commit: {
+        raw: singleFooter,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with footer",
+        body: undefined,
+        footer: {
+          "Acknowledged-by": "Jane Doe",
+        },
       },
     });
 
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: multiFooter })).toStrictEqual({
-      raw: multiFooter,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with footer",
-      body: undefined,
-      footer: {
-        "Acknowledged-by": "Jane Doe",
-        "Signed-off-by": "John Doe",
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: multiFooter })).toEqual({
+      _commit: {
+        raw: multiFooter,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with footer",
+        body: undefined,
+        footer: {
+          "Acknowledged-by": "Jane Doe",
+          "Signed-off-by": "John Doe",
+        },
       },
     });
 
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: paragraphFooter })).toStrictEqual({
-      raw: paragraphFooter,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with footer",
-      body: undefined,
-      footer: {
-        "Acknowledged-by": "Jane Doe",
-        "Signed-off-by": "John Doe",
-        "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: paragraphFooter })).toEqual({
+      _commit: {
+        raw: paragraphFooter,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with footer",
+        body: undefined,
+        footer: {
+          "Acknowledged-by": "Jane Doe",
+          "Signed-off-by": "John Doe",
+          "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
+        },
       },
     });
   });
@@ -189,18 +207,20 @@ BREAKING-CHANGE: This is a breaking change
  using multiple lines as value
 Implements #1234`;
 
-    expect(commitIt.getCommit({ hash: "0a0b0c0d", message: fullCommit })).toStrictEqual({
-      raw: fullCommit,
-      hash: "0a0b0c0d",
-      author: undefined,
-      committer: undefined,
-      subject: "Example commit message with footer",
-      body: "This is the body of the commit message\nwith multiple lines\n\nand: paragraphs as well",
-      footer: {
-        "Acknowledged-by": "Jane Doe",
-        "Signed-off-by": "John Doe",
-        "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
-        Implements: "#1234",
+    expect(Commit.fromString({ hash: "0a0b0c0d", message: fullCommit })).toEqual({
+      _commit: {
+        raw: fullCommit,
+        hash: "0a0b0c0d",
+        author: undefined,
+        committer: undefined,
+        subject: "Example commit message with footer",
+        body: "This is the body of the commit message\nwith multiple lines\n\nand: paragraphs as well",
+        footer: {
+          "Acknowledged-by": "Jane Doe",
+          "Signed-off-by": "John Doe",
+          "BREAKING-CHANGE": "This is a breaking change\nusing multiple lines as value",
+          Implements: "#1234",
+        },
       },
     });
   });

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -14,6 +14,7 @@ describe("Parse commit messages", () => {
         message: "Example commit message without body or footer",
       })
     ).toStrictEqual({
+      raw: `Example commit message without body or footer`,
       hash: "0a0b0c0d",
       author: {
         name: "Jane Doe",
@@ -34,6 +35,7 @@ describe("Parse commit messages", () => {
         message: "Example commit message without body or footer",
       })
     ).toStrictEqual({
+      raw: `Example commit message without body or footer`,
       hash: "0a0b0c0d",
       author: undefined,
       committer: {
@@ -50,6 +52,7 @@ describe("Parse commit messages", () => {
     expect(
       commitIt.getCommit({ hash: "0a0b0c0d", message: "Example commit message without body or footer" })
     ).toStrictEqual({
+      raw: `Example commit message without body or footer`,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -61,6 +64,7 @@ describe("Parse commit messages", () => {
     expect(
       commitIt.getCommit({ hash: "0a0b0c0d", message: `Example commit message without body or footer, with newline\n` })
     ).toStrictEqual({
+      raw: `Example commit message without body or footer, with newline\n`,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -75,6 +79,7 @@ describe("Parse commit messages", () => {
         message: `Example commit message without body or footer, with newlines\n\n`,
       })
     ).toStrictEqual({
+      raw: `Example commit message without body or footer, with newlines\n\n`,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -95,6 +100,7 @@ with multiple lines
 
 and paragraphs`;
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: singleBody })).toStrictEqual({
+      raw: singleBody,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -104,6 +110,7 @@ and paragraphs`;
     });
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: multiBody })).toStrictEqual({
+      raw: multiBody,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -129,6 +136,7 @@ BREAKING-CHANGE: This is a breaking change
  using multiple lines as value`;
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: singleFooter })).toStrictEqual({
+      raw: singleFooter,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -140,6 +148,7 @@ BREAKING-CHANGE: This is a breaking change
     });
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: multiFooter })).toStrictEqual({
+      raw: multiFooter,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -152,6 +161,7 @@ BREAKING-CHANGE: This is a breaking change
     });
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: paragraphFooter })).toStrictEqual({
+      raw: paragraphFooter,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,
@@ -180,6 +190,7 @@ BREAKING-CHANGE: This is a breaking change
 Implements #1234`;
 
     expect(commitIt.getCommit({ hash: "0a0b0c0d", message: fullCommit })).toStrictEqual({
+      raw: fullCommit,
       hash: "0a0b0c0d",
       author: undefined,
       committer: undefined,


### PR DESCRIPTION
This PR introduces:
- Support for Conventional Commit specification item 6
- Support for Conventional Commit specification item 15
- Warnings for incorrect usage of BREAKING-CHANGE

Unfortunately, this required a significant rework of the public API, hence a breaking change.

Please refer to the individual commit messages for more details