### PR TITLE
fix: type and scope are no longer provided as raw data

### DIFF
--- a/src/conventionalCommit.ts
+++ b/src/conventionalCommit.ts
@@ -149,9 +149,13 @@ export class ConventionalCommit {
 
   // Conventional Commit
   get type(): string | undefined {
-    return this._raw.type.value;
+    return this._raw.type.value?.trimEnd();
   }
   get scope(): string | undefined {
+    // Removes the parenthesis from the scope
+    if (this._raw.scope.value !== undefined) {
+      return this._raw.scope.value.trimEnd().replace(/(\(|\))/g, "");
+    }
     return this._raw.scope.value;
   }
   get description(): string | undefined {
@@ -160,7 +164,7 @@ export class ConventionalCommit {
 
   get breaking(): boolean {
     return (
-      this._raw.breaking.value === "!" ||
+      this._raw.breaking.value?.trimEnd() === "!" ||
       (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer))
     );
   }

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -212,33 +212,50 @@ describe("WA-01", () => {
 });
 
 describe("Breaking Change", () => {
-  test("Has breaking change", () => {
-    expect(
-      ConventionalCommit.fromString({ hash: "01ab2cd3", message: "feat: add new feature with breaking change" })
-        .breaking
-    ).toBe(false);
+  const tests = [
+    { message: "feat: add new feature", isBreaking: false },
+    { message: "fix: fix bug", isBreaking: false },
+    { message: "fix!: fix bug with breaking change", isBreaking: true },
+    { message: "fix! : fix bug with breaking change with incorrect whitespace", isBreaking: true },
+    { message: "fix(no noun)! : fix bug with breaking change with incorrect whitespace and scope", isBreaking: true },
+    { message: "feat!: add new feature with breaking change", isBreaking: true },
+    { message: "chore: add new feature with breaking change in footer\n\nBREAKING CHANGE: this is a breaking change", isBreaking: true },
+    { message: "chore: add new feature with breaking change in footer\n\nBREAKING-CHANGE: this is a breaking change", isBreaking: true },
+    { message: "chore: add new feature with breaking change in body\n\nBREAKING-CHANGE: this is a breaking change\n\nNew paragraph", isBreaking: false },
+  ];
 
-    expect(
-      ConventionalCommit.fromString({ hash: "01ab2cd3", message: "feat!: add new feature with breaking change" })
-        .breaking
-    ).toBe(true);
+  it.each(tests)("$message", test => {
+    const commit = ConventionalCommit.fromString({ hash: "01ab2cd3", message: test.message });
+    expect(commit.breaking).toBe(test.isBreaking);
+  });
+});
 
-    expect(
-      ConventionalCommit.fromString({
-        hash: "01ab2cd3",
-        message: `feat!: add new feature with breaking change in footer
+describe("Scope", () => {
+  const tests = [
+    { message: "feat: no scope", valid: true, scope: undefined },
+    { message: "feat(no noun): wrong scope", valid: false, scope: "no noun" },
+    { message: "feat (cli): correct scope, whitespacing", valid: false, scope: "cli"},
+    { message: "feat (cli) : correct scope, whitespacing part deux", valid: false, scope: "cli"}
+  ];
 
-BREAKING CHANGE: this is a breaking change`,
-      }).breaking
-    ).toBe(true);
+  it.each(tests)("$message", test => {
+    const commit = ConventionalCommit.fromString({ hash: "01ab2cd3", message: test.message });
+    expect(commit.isValid).toBe(test.valid);
+    expect(commit.scope).toBe(test.scope);
+  });
+});
 
-    expect(
-      ConventionalCommit.fromString({
-        hash: "01ab2cd3",
-        message: `feat: add new feature with breaking change in footer
+describe("Type", () => {
+  const tests = [
+    { message: "feat: no scope", valid: true, type: "feat" },
+    { message: "feat(no noun): wrong scope", valid: false, type: "feat" },
+    { message: "no noun(cli): wrong type", valid: false, type: "no noun"},
+    { message: "feat : correct scope, whitespacing", valid: false, type: "feat"}
+  ];
 
-BREAKING-CHANGE: this is a breaking change`,
-      }).breaking
-    ).toBe(true);
+  it.each(tests)("$message", test => {
+    const commit = ConventionalCommit.fromString({ hash: "01ab2cd3", message: test.message });
+    expect(commit.isValid).toBe(test.valid);
+    expect(commit.type).toBe(test.type);
   });
 });


### PR DESCRIPTION
The fields `type`, `scope`, and (in limited capacity also `breaking`) could return raw values in case of an "Invalid" Conventional Commit.

This change will:
- Trim the fields for excess whitespacing
- Remove the () from the scope field