### PR TITLE
fix: ignore comments (#) when parsing a commit from string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 # SPDX-License-Identifier: CC0-1.0
 
-node_modules
+node_modules/
 npm-debug.log
 lib/
 coverage/

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -82,9 +82,16 @@ export class Commit {
     author?: { name: string; date: Date };
     committer?: { name: string; date: Date };
   }): Commit {
+    // Git will trim all comments (lines starting with #), so we do the same
+    // to ensure the commit message is parsed correctly.
+    const trimmedMessage = props.message
+      .split(/\r?\n/)
+      .filter(line => !line.startsWith("#"))
+      .join("\n");
+
     const commit = {
       hash: props.hash,
-      ...parseCommitMessage(props.message),
+      ...parseCommitMessage(trimmedMessage),
       author: props.author,
       committer: props.committer,
       raw: props.message,

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -219,9 +219,19 @@ describe("Breaking Change", () => {
     { message: "fix! : fix bug with breaking change with incorrect whitespace", isBreaking: true },
     { message: "fix(no noun)! : fix bug with breaking change with incorrect whitespace and scope", isBreaking: true },
     { message: "feat!: add new feature with breaking change", isBreaking: true },
-    { message: "chore: add new feature with breaking change in footer\n\nBREAKING CHANGE: this is a breaking change", isBreaking: true },
-    { message: "chore: add new feature with breaking change in footer\n\nBREAKING-CHANGE: this is a breaking change", isBreaking: true },
-    { message: "chore: add new feature with breaking change in body\n\nBREAKING-CHANGE: this is a breaking change\n\nNew paragraph", isBreaking: false },
+    {
+      message: "chore: add new feature with breaking change in footer\n\nBREAKING CHANGE: this is a breaking change",
+      isBreaking: true,
+    },
+    {
+      message: "chore: add new feature with breaking change in footer\n\nBREAKING-CHANGE: this is a breaking change",
+      isBreaking: true,
+    },
+    {
+      message:
+        "chore: add new feature with breaking change in body\n\nBREAKING-CHANGE: this is a breaking change\n\nNew paragraph",
+      isBreaking: false,
+    },
   ];
 
   it.each(tests)("$message", test => {
@@ -234,8 +244,8 @@ describe("Scope", () => {
   const tests = [
     { message: "feat: no scope", valid: true, scope: undefined },
     { message: "feat(no noun): wrong scope", valid: false, scope: "no noun" },
-    { message: "feat (cli): correct scope, whitespacing", valid: false, scope: "cli"},
-    { message: "feat (cli) : correct scope, whitespacing part deux", valid: false, scope: "cli"}
+    { message: "feat (cli): correct scope, whitespacing", valid: false, scope: "cli" },
+    { message: "feat (cli) : correct scope, whitespacing part deux", valid: false, scope: "cli" },
   ];
 
   it.each(tests)("$message", test => {
@@ -249,13 +259,29 @@ describe("Type", () => {
   const tests = [
     { message: "feat: no scope", valid: true, type: "feat" },
     { message: "feat(no noun): wrong scope", valid: false, type: "feat" },
-    { message: "no noun(cli): wrong type", valid: false, type: "no noun"},
-    { message: "feat : correct scope, whitespacing", valid: false, type: "feat"}
+    { message: "no noun(cli): wrong type", valid: false, type: "no noun" },
+    { message: "feat : correct scope, whitespacing", valid: false, type: "feat" },
   ];
 
   it.each(tests)("$message", test => {
     const commit = ConventionalCommit.fromString({ hash: "01ab2cd3", message: test.message });
     expect(commit.isValid).toBe(test.valid);
     expect(commit.type).toBe(test.type);
+  });
+});
+
+describe("Commit message ends at first comment (#)", () => {
+  const tests = [
+    { message: "feat: no scope\n# This is a comment", breaking: false },
+    { message: "feat: no scope\n# This is a comment\n# which spans multiple lines", breaking: false },
+    { message: "feat: no scope\n# This is a comment\n\nBREAKING-CHANGE: This should not be ignored", breaking: true },
+  ];
+
+  it.each(tests)("$message", test => {
+    const commit = ConventionalCommit.fromString({ hash: "01ab2cd3", message: test.message });
+
+    expect(commit.isValid).toBe(true);
+    expect(commit.type).toBe("feat");
+    expect(commit.breaking).toBe(test.breaking);
   });
 });


### PR DESCRIPTION
This commit will ensure that we ignore any comments in commit messages when parsed `fromString`, i.e.:

```
feat: add amazing button
# It is not really that amazing...

This commit introduces an amazing button which, when pressed, does
even more amazing things.
# It only changes color?

Implements #123
```

Should be parsed as:
```
feat: add amazing button

This commit introduces an amazing button which, when pressed, does
even more amazing things.

Implements #123
```

> [!NOTE]
> This replicates the behavior of `git` (as can be achieved with the `Commit.fromHash`)

Addresses #32